### PR TITLE
configure successfuly with installed linux packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ if(${CMAKE_MAJOR_VERSION} STREQUAL "3")
   cmake_policy(SET CMP0042 OLD)
 
   # CMake 3.1 introduces if() policies on dereferencing variables in quotes
-  if(${CMAKE_MINOR_VERSION} VERSION_GREATER "3.0.2") 
+  if(${CMAKE_MINOR_VERSION} VERSION_GREATER "3.0.2")
     cmake_policy(SET CMP0054 NEW)
   endif()
 
@@ -189,12 +189,6 @@ if("${HDF5_INSTALL}" STREQUAL "")
     set(HDF5_INSTALL  $ENV{HDF5_INSTALL})
 endif()
 
-if( "${HDF5_INSTALL}" STREQUAL "")
-  message(FATAL_ERROR "The HDF5_INSTALL variable was not set. In order to find HDF5 you need to either\
-                      pass in the -DHDF5_INSTALL=.... or set the HDF5_INSTALL environment variable.")
-endif()
-
-
 if(WIN32)
     set(ENV{HDF5_ROOT_DIR_HINT} "${HDF5_INSTALL}/cmake/hdf5")
     set(ENV{HDF5_ROOT} "${HDF5_INSTALL}")
@@ -236,7 +230,12 @@ if(HDF5_FOUND)
                         TYPES ${BUILD_TYPES})
   endif()
 ELSE(HDF5_FOUND)
-    MESSAGE(FATAL_ERROR "Cannot build without HDF5.  Please set HDF5_INSTALL environment variable to point to your HDF5 installation.")
+    if( "${HDF5_INSTALL}" STREQUAL "")
+        message(FATAL_ERROR "Cannot build without HDF5. The HDF5_INSTALL variable was not set. In order to find HDF5 you need to either\
+                      pass in the -DHDF5_INSTALL=.... or set the HDF5_INSTALL environment variable.")
+    else()
+        MESSAGE(FATAL_ERROR "Cannot build without HDF5.  Please set HDF5_INSTALL environment variable to point to your HDF5 installation.")
+    endif()
 ENDif(HDF5_FOUND)
 
 # --------------------------------------------------------------------

--- a/Support/cmp/Modules/FindEigen.cmake
+++ b/Support/cmp/Modules/FindEigen.cmake
@@ -16,6 +16,7 @@ endif()
 
 SET(EIGEN_INCLUDE_SEARCH_DIRS
   ${EIGEN_INSTALL}/include/eigen3
+  /usr/include/eigen3
 )
 
 FIND_PATH(EIGEN_INCLUDE_DIR

--- a/Support/cmp/Modules/FindQwt.cmake
+++ b/Support/cmp/Modules/FindQwt.cmake
@@ -28,12 +28,14 @@ SET(QWT_INCLUDE_SEARCH_DIRS
   ${QWT_INSTALL}/include/qwt5
   ${QWT_INSTALL}/include
   /usr/include/qwt5
+  /usr/include/qwt
   ${QWT_INSTALL}/lib/qwt.framework/Headers
 )
 
 set(QWT_LIB_SEARCH_DIRS
   ${QWT_INSTALL}/lib
   ${QWT_INSTALL}/lib/qwt.framework/
+  /usr/lib/
   )
 
 set(QWT_BIN_SEARCH_DIRS

--- a/Support/cmp/Modules/FindTBB.cmake
+++ b/Support/cmp/Modules/FindTBB.cmake
@@ -153,14 +153,14 @@ if(NOT _TBB_INSTALL_DIR)
     endif(_TBB_DEFAULT_INSTALL_DIR)
 endif(NOT _TBB_INSTALL_DIR)
 # sanity check
-if(NOT _TBB_INSTALL_DIR)
+if(NOT _TBB_INSTALL_DIR AND WIN32)
     message ("ERROR: TBB_INSTALL_DIR not found. ${_TBB_INSTALL_DIR}")
-else (NOT _TBB_INSTALL_DIR)
+else()
 # finally: set the cached CMake variable TBB_INSTALL_DIR
-if(NOT TBB_INSTALL_DIR)
+if(NOT TBB_INSTALL_DIR AND WIN32)
     set(TBB_INSTALL_DIR ${_TBB_INSTALL_DIR} CACHE PATH "Intel TBB install directory")
     mark_as_advanced(TBB_INSTALL_DIR)
-endif(NOT TBB_INSTALL_DIR)
+endif()
 
 if(TBB_DEBUG)
 	message(STATUS "*** TBB Variables Calculated")
@@ -185,7 +185,7 @@ endmacro(TBB_CORRECT_LIB_DIR var_content)
 
 
 #-- Look for include directory and set ${TBB_INCLUDE_DIR}
-set(TBB_INC_SEARCH_DIR ${_TBB_INSTALL_DIR}/include)
+set(TBB_INC_SEARCH_DIR ${_TBB_INSTALL_DIR}/include /usr/include)
 find_path(TBB_INCLUDE_DIR
     tbb/task_scheduler_init.h
     PATHS ${TBB_INC_SEARCH_DIR}
@@ -200,6 +200,7 @@ mark_as_advanced(TBB_INCLUDE_DIR)
 set(_TBB_LIBRARY_DIR
 	 ${_TBB_INSTALL_DIR}/lib/${TBB_ARCH_PLATFORM}
 	 ${_TBB_INSTALL_DIR}/${TBB_ARCH_PLATFORM}/lib
+	/usr/lib
 	)
 	
 find_library(TBB_LIBRARY_RELEASE


### PR DESCRIPTION
I added these fixes to see the cmake include path problems on Linux, but when I use a build from qt-creator/3.3 I don't see the errors.

Which files does not work for you?

I haven't tested the released 3.3, because I have downgraded to 3.2 because of this error.