### PR TITLE
updating the quaternion math test to fix failing test

### DIFF
--- a/Source/OrientationLib/OrientationMath/OrientationMath.cpp
+++ b/Source/OrientationLib/OrientationMath/OrientationMath.cpp
@@ -645,6 +645,23 @@ void OrientationMath::EulerToAxisAngle(float ea1, float ea2, float ea3, float& w
   // Convert the Rodrigues to Axis Angle
   RodtoAxisAngle(r1, r2, r3, w, n1, n2, n3);
 }
+
+// -----------------------------------------------------------------------------
+//
+// -----------------------------------------------------------------------------
+void OrientationMath::MultiplyQuaternionVector(QuatF& inQuat, float* inVec, float* outVec)
+{
+  float g[3][3];
+  float gInv[3][3];
+
+  FOrientArrayType om(9, 0.0f);
+  FOrientTransformsType::qu2om(FOrientArrayType(inQuat), om);
+  om.toGMatrix(g);
+
+  MatrixMath::Invert3x3(g, gInv);
+  MatrixMath::Multiply3x3with3x1(gInv, inVec, outVec);
+}
+
 #endif
 
 // -----------------------------------------------------------------------------
@@ -672,25 +689,6 @@ void OrientationMath::EulertoMatActive(float ea1, float ea2, float ea3, float g[
   g[2][1] = cp2 * sp;
   g[2][2] = cp;
 }
-
-
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
-void OrientationMath::MultiplyQuaternionVector(QuatF& inQuat, float* inVec, float* outVec)
-{
-  float g[3][3];
-  float gInv[3][3];
-
-  FOrientArrayType om(9, 0.0f);
-  FOrientTransformsType::qu2om(FOrientArrayType(inQuat), om);
-  om.toGMatrix(g);
-
-  MatrixMath::Invert3x3(g, gInv);
-  MatrixMath::Multiply3x3with3x1(gInv, inVec, outVec);
-}
-
 
 // -----------------------------------------------------------------------------
 //

--- a/Source/OrientationLib/Test/QuaternionMathTest.cpp
+++ b/Source/OrientationLib/Test/QuaternionMathTest.cpp
@@ -63,55 +63,6 @@ void RemoveTestFiles()
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
-void TestVectorRotation()
-{
-  QuatF equat;
-
-  FOrientArrayType eu(DREAM3D::Constants::k_PiOver2, DREAM3D::Constants::k_PiOver2, DREAM3D::Constants::k_PiOver2);
-  FOrientArrayType qu(4);
-  OrientationTransforms<FOrientArrayType, float>::eu2qu(eu, qu);
-
-  equat = qu.toQuaternion();
-
-  CubicOps cubic;
-  int nsym = cubic.getNumSymOps();
-  QuatF sym_q;
-  float xstl_norm[3] = {1.0, 0.0, 0.0};
-  // std::cout << "xstl_norm: " << xstl_norm[0] << ", " << xstl_norm[1] << ", " << xstl_norm[2]  << std::endl;
-  float s_xstl_norm_rot[3];
-  float s_xstl_norm_quat[3];
-  float delta[3];
-  for (int j = 0; j < nsym; j++)
-  {
-    cubic.getQuatSymOp(j, sym_q);
-    // std::cout << "sym_q: " << sym_q.w << ", <" << sym_q.x << ", " << sym_q.y << ", " << sym_q.z << ">"  << std::endl;
-    OrientationMath::MultiplyQuaternionVector(sym_q, xstl_norm, s_xstl_norm_rot);
-    // std::cout << "Rotation Matrix: " << s_xstl_norm_rot[0] << ", " << s_xstl_norm_rot[1] << ", " << s_xstl_norm_rot[2]  << std::endl;
-    QuaternionMathF::MultiplyQuatVec(sym_q, xstl_norm, s_xstl_norm_quat);
-    // std::cout << "Quaternion:      " << s_xstl_norm_quat[0] << ", " << s_xstl_norm_quat[1] << ", " << s_xstl_norm_quat[2]  << std::endl;
-
-    delta[0] = s_xstl_norm_rot[0] - s_xstl_norm_quat[0];
-    delta[1] = s_xstl_norm_rot[1] - s_xstl_norm_quat[1];
-    delta[2] = s_xstl_norm_rot[2] - s_xstl_norm_quat[2];
-
-    DREAM3D_REQUIRE(delta[0] >= -std::numeric_limits<float>::epsilon() && delta[0] <= std::numeric_limits<float>::epsilon())
-    DREAM3D_REQUIRE(delta[1] >= -std::numeric_limits<float>::epsilon() && delta[1] <= std::numeric_limits<float>::epsilon())
-    DREAM3D_REQUIRE(delta[2] >= -std::numeric_limits<float>::epsilon() && delta[2] <= std::numeric_limits<float>::epsilon())
-
-    // QuatF passive = OrientationMath::PassiveRotation(0.5, 0.5, 0.5, -0.5, 1, 0, 0);
-    // std::cout << "passive: " << passive.w << ", <" << passive.x << ", " << passive.y << ", " << passive.z << ">"  << std::endl;
-
-    // QuatF active = OrientationMath::ActiveRotation(0.5, 0.5, 0.5, -0.5, 1, 0, 0);
-    // std::cout << "active: " << active.w << ", <" << active.x << ", " << active.y << ", " << active.z << ">"  << std::endl;
-
-
-
-  }
-}
-
-// -----------------------------------------------------------------------------
-//
-// -----------------------------------------------------------------------------
 void TestQuat_t()
 {
   QuatF p = QuaternionMathF::New(1.0f, 0.0f, 0.0f, 1.0f);
@@ -292,10 +243,8 @@ int main(int argc, char* argv[])
 {
   int err = EXIT_SUCCESS;
   DREAM3D_REGISTER_TEST( TestQuat_t() )
-  DREAM3D_REGISTER_TEST( TestVectorRotation() )
   DREAM3D_REGISTER_TEST( RemoveTestFiles() )
   PRINT_TEST_SUMMARY();
 
-  // TestVectorRotation();
   return err;
 }

--- a/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundaries.cpp
+++ b/Source/Plugins/OrientationAnalysis/OrientationAnalysisFilters/FindTwinBoundaries.cpp
@@ -149,7 +149,7 @@ class CalculateTwinBoundaryImpl
               // calculate crystal direction parallel to normal
 			        QuaternionMathF::Multiply(misq, sym_q, s1_misq);
 
-              if(m_FindCoherence) { OrientationMath::MultiplyQuaternionVector(sym_q, xstl_norm, s_xstl_norm); }
+              if (m_FindCoherence) { QuaternionMathF::MultiplyQuatVec(sym_q, xstl_norm, s_xstl_norm); }
 
               for (int32_t k = 0; k < nsym; k++)
               {


### PR DESCRIPTION
removing the vector rotation test from the quaternion math test - to ……get rid of failing test that is no longer needed.  the old rotate vector with quaternion function in orientation math was also moved into the non compiled portion of orientation math waiting to be removed.  two filters were updated to use the new rotate vector with quaternion function from M. DeGraef