### PR TITLE
Bugfix for FindElementNeighbors in GeometryHelpers

### DIFF
--- a/Source/DREAM3DLib/DataArrays/DynamicListArray.hpp
+++ b/Source/DREAM3DLib/DataArrays/DynamicListArray.hpp
@@ -187,6 +187,20 @@ class DynamicListArray
       }
     }
 
+	/**
+	* @brief allocateLists
+	* @param linkCounts
+	*/
+	void allocateLists(QVector<T>& linkCounts)
+	{
+		allocate(linkCounts.size());
+		for (K i = 0; i < linkCounts.size(); i++)
+		{
+			this->m_Array[i].ncells = linkCounts[i];
+			this->m_Array[i].cells = new K[this->m_Array[i].ncells];
+		}
+	}
+
     /**
      * @brief allocateLists
      * @param linkCounts

--- a/Source/DREAM3DLib/Geometry/GeometryHelpers.hpp
+++ b/Source/DREAM3DLib/Geometry/GeometryHelpers.hpp
@@ -282,6 +282,9 @@ namespace GeometryHelpers
           break;
         }
 
+		// Now allocate storage for the links
+		dynamicList->allocateLists(linkCount);
+
         // Allocate an array of bools that we use each iteration so that we don't put duplicates into the array
         boost::shared_array<bool> visitedPtr(new bool[numElems]);
         bool* visited = visitedPtr.get();
@@ -315,7 +318,7 @@ namespace GeometryHelpers
               {
                 for (size_t j = 0; j < numVertsPerElem; j++)
                 {
-                  if (seedElem[i] == vertCell[i])
+                  if (seedElem[i] == vertCell[j])
                   {
                     vCount++;
                   }


### PR DESCRIPTION
Previously, generating the Triangle Neighbors List in the Generate Geometry Connectivity Filter resulted in the code silently failing because of a minor typo in a for loop.  No neighbors were ever recognized.  Additionally, even if the loop were okay, memory for the storage list was never allocated and would also silently fail.

This fix corrects the typo in the for loop in GeometryHelpers.hpp and also adds another overloaded version of allocateLists to support the type of this list so that allocation can occur.   Not 100% sure if  the latter fix is necessarily the best course of action, but it fixes the problem regardless.

Let me know if there is anything you guys would like done differently or fixed in this pull request.

Thanks!