### PR TITLE
removing the transformation and boundary phase options from throughout

### DIFF
--- a/Source/Applications/StatsGenerator/UI_Files/EditPhaseDialog.ui
+++ b/Source/Applications/StatsGenerator/UI_Files/EditPhaseDialog.ui
@@ -139,17 +139,7 @@
        </item>
        <item>
         <property name="text">
-         <string>Transformation</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
          <string>Matrix</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Boundary</string>
         </property>
        </item>
        <item>

--- a/Source/DREAM3DLib/Common/Constants.h
+++ b/Source/DREAM3DLib/Common/Constants.h
@@ -576,8 +576,8 @@ namespace DREAM3D
   {
     const unsigned int PrimaryPhase = 0;              //!<
     const unsigned int PrecipitatePhase = 1;          //!<
-    const unsigned int TransformationPhase = 2;       //!<
-    const unsigned int MatrixPhase = 3;              //!<
+    const unsigned int MatrixPhase = 2;              //!<
+    const unsigned int TransformationPhase = 3;       //!<
     const unsigned int BoundaryPhase = 4;              //!<
     const unsigned int UnknownPhaseType = 999;    //!<
 

--- a/Source/DREAM3DLib/Common/PhaseType.h
+++ b/Source/DREAM3DLib/Common/PhaseType.h
@@ -60,9 +60,9 @@ class DREAM3DLib_EXPORT PhaseType
 
     static QString PrimaryStr() { return QString("Primary"); }
     static QString PrecipitateStr() { return QString("Precipitate"); }
-    static QString TransformationStr() { return QString("Transformation"); }
+//    static QString TransformationStr() { return QString("Transformation"); }
     static QString MatrixStr() { return QString("Matrix"); }
-    static QString BoundaryStr() { return QString("Boundary"); }
+//    static QString BoundaryStr() { return QString("Boundary"); }
     static QString UnknownPhaseTypeStr() { return QString("Unknown Phase Type"); }
 
 
@@ -74,12 +74,12 @@ class DREAM3DLib_EXPORT PhaseType
           return PrimaryStr();
         case DREAM3D::PhaseType::PrecipitatePhase:
           return PrecipitateStr();
-        case DREAM3D::PhaseType::TransformationPhase:
-          return TransformationStr();
+        //case DREAM3D::PhaseType::TransformationPhase:
+        //  return TransformationStr();
         case DREAM3D::PhaseType::MatrixPhase:
           return MatrixStr();
-        case DREAM3D::PhaseType::BoundaryPhase:
-          return BoundaryStr();
+        //case DREAM3D::PhaseType::BoundaryPhase:
+        //  return BoundaryStr();
         case DREAM3D::PhaseType::UnknownPhaseType:
           return UnknownPhaseTypeStr();
         default:
@@ -98,18 +98,18 @@ class DREAM3DLib_EXPORT PhaseType
       {
         return DREAM3D::PhaseType::PrecipitatePhase;
       }
-      else if (TransformationStr().compare(str) == 0)
-      {
-        return DREAM3D::PhaseType::TransformationPhase;
-      }
+      //else if (TransformationStr().compare(str) == 0)
+      //{
+      //  return DREAM3D::PhaseType::TransformationPhase;
+      //}
       else if (MatrixStr().compare(str) == 0)
       {
         return DREAM3D::PhaseType::MatrixPhase;
       }
-      else if (BoundaryStr().compare(str) == 0)
-      {
-        return DREAM3D::PhaseType::BoundaryPhase;
-      }
+      //else if (BoundaryStr().compare(str) == 0)
+      //{
+      //  return DREAM3D::PhaseType::BoundaryPhase;
+      //}
       return DREAM3D::PhaseType::UnknownPhaseType;
     }
 
@@ -119,9 +119,9 @@ class DREAM3DLib_EXPORT PhaseType
       strings.clear();
       strings.push_back(PrimaryStr());
       strings.push_back(PrecipitateStr());
-      strings.push_back(TransformationStr());
       strings.push_back(MatrixStr());
-      strings.push_back(BoundaryStr());
+      //strings.push_back(TransformationStr());
+      //strings.push_back(BoundaryStr());
       strings.push_back(UnknownPhaseTypeStr());
     }
 
@@ -130,9 +130,9 @@ class DREAM3DLib_EXPORT PhaseType
       types.clear();
       types.push_back(DREAM3D::PhaseType::PrimaryPhase);
       types.push_back(DREAM3D::PhaseType::PrecipitatePhase);
-      types.push_back(DREAM3D::PhaseType::TransformationPhase);
       types.push_back(DREAM3D::PhaseType::MatrixPhase);
-      types.push_back(DREAM3D::PhaseType::BoundaryPhase);
+      //types.push_back(DREAM3D::PhaseType::TransformationPhase);
+      //types.push_back(DREAM3D::PhaseType::BoundaryPhase);
       types.push_back(DREAM3D::PhaseType::UnknownPhaseType);
     }
 
@@ -141,9 +141,9 @@ class DREAM3DLib_EXPORT PhaseType
       map.clear();
       map[DREAM3D::PhaseType::PrimaryPhase] = PrimaryStr();
       map[DREAM3D::PhaseType::PrecipitatePhase] = PrecipitateStr();
-      map[DREAM3D::PhaseType::TransformationPhase] = TransformationStr();
+      //map[DREAM3D::PhaseType::TransformationPhase] = TransformationStr();
       map[DREAM3D::PhaseType::MatrixPhase] = MatrixStr();
-      map[DREAM3D::PhaseType::BoundaryPhase] = BoundaryStr();
+      //map[DREAM3D::PhaseType::BoundaryPhase] = BoundaryStr();
       map[DREAM3D::PhaseType::UnknownPhaseType] = UnknownPhaseTypeStr();
     }
 


### PR DESCRIPTION
I removed the transformation and boundary phase options from the stats generator phase properties manager.  the enumeration of phase types had to be updated, but probably should have been in this order anyway.  I also updated the generate ensemble stats filter to not have those options either.  This last things required updating the phase type class to no longer have the transformation and boundary phases "active"
