### PR TITLE
FIX: In Linux the property IMPORTED_LOCATION_<CONFIG>

### DIFF
--- a/Support/ITKSupport/IncludeITK.cmake
+++ b/Support/ITKSupport/IncludeITK.cmake
@@ -32,7 +32,7 @@ function(AddITKCopyInstallRules)
 
     if(TARGET ${Z_LIBNAME})
 
-      GET_TARGET_PROPERTY(LibPath ${Z_LIBNAME} IMPORTED_LOCATION_${TYPE})
+      GET_TARGET_PROPERTY(LibPath ${Z_LIBNAME} LOCATION_${TYPE})
       GET_TARGET_PROPERTY(LibType ${Z_LIBNAME} TYPE)
 
       if(0)


### PR DESCRIPTION
does not return a path for ITK libraries. Replace it
by LOCATION_<CONFIG>.